### PR TITLE
Enable Sopo bool for Powershield Training

### DIFF
--- a/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
+++ b/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
@@ -3690,7 +3690,7 @@ Powershield:
 	li	r5,Falco.Ext						#Use chosen CPU
 	li	r6,FinalDestination			#Use SSS Stage
 	load r7,EventOSD_Powershield
-	li	r8,0										#Use Sopo bool
+	li	r8,1										#Use Sopo bool
 	bl	InitializeMatch
 
 #STORE THINK FUNCTION


### PR DESCRIPTION
Powershielding falco's lasers is an option that arguably becomes more appealing without Nana. Even ICs who wish to practice powershielding with both climbers won't mind this change as its difficult to accidentally kill nana in this event. Being able to swap which side falco is on without respawning nana will be a nice quality life change for ICs players.